### PR TITLE
feat: add icon_padding setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ hold_action:
 | border_radius     | string  | **Optional** | Border radius including units (CSS format)     | form theme          |
 | border_style      | string  | **Optional** | Border style (CSS format)                      | form theme          |
 | border_width      | string  | **Optional** | Border width (CSS format)                      | form theme          |
+| icon_padding      | string  | **Optional** | Padding around the icon (CSS format)           | form theme          |
 | colorize          | boolean | **Optional** | Colorize slider using entity color             | false               |
 | icon              | string  | **Optional** | Sets custom icon                               | entity icon         |
 | show_percentage   | boolean | **Optional** | Show percentage under entity name              | false               |
@@ -110,6 +111,7 @@ For more info about the rest of the action options see this page: [Actions - Hom
 --bsc-border-radius: var(--ha-card-border-radius);
 --bsc-border-style: var(--ha-card-border-style);
 --bsc-border-width: var(--ha-card-border-width);
+--bsc-icon-padding: 24px;
 ```
 
 

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -409,6 +409,7 @@ export class BigSliderCard extends LitElement {
     this._setStyleProperty('--bsc-border-style', this._config.border_style);
     this._setStyleProperty('--bsc-border-width', this._config.border_width);
     this._setStyleProperty('--bsc-height', this._config.height, (height) => `${height}px`);
+    this._setStyleProperty('--bsc-icon-padding', this._config.icon_padding, (padding) => `${padding}px`);
 
     return html`
       <ha-card
@@ -480,6 +481,7 @@ export class BigSliderCard extends LitElement {
         --bsc-border-width: var(--ha-card-border-width);
         --bsc-height: var(--ha-card-height, 60px);
         --bsc-opacity: 1;
+        --bsc-icon-padding: 24px;
 
 
         display: flex;
@@ -541,7 +543,7 @@ export class BigSliderCard extends LitElement {
         position: absolute;
         top: 0;
         bottom: 0;
-        left: 24px;
+        left: var(--bsc-icon-padding);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -557,7 +559,7 @@ export class BigSliderCard extends LitElement {
         display: flex;
         justify-content: flex-start;
         align-items: center;
-        padding: 0 24px 0 72px;
+        padding: 0 24px 0 calc(2 * var(--bsc-icon-padding) + 24px);
         box-sizing: border-box;
       }
 


### PR DESCRIPTION
I wanted to reduce the space between the left side of the card and the icon, as wel as the space between the icon and the text, so I added a setting and figure I'd open a PR for it.

The setting takes the padding that should be kept around the icon in pixels. This is then applied to the absolutely positioned icon's `left` property, and we adjust the left padding around the content div (which is 72px by default) to be twice the given value plus 24 pixels for the width of the icon itself.

Edit: I just realised I didn't include a new built version, let me know if you want me to do that and I'll update the PR.