### PR TITLE
feat: add slider_opacity setting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+jobs:
+    build:
+        runs-on: 'ubuntu-latest'
+        steps:
+            - uses: actions/checkout@master
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: '10.x'
+            - run: yarn install
+            - run: yarn build
+            - id: create_release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: ${{ github.ref }}
+                  draft: false
+                  prerelease: false
+            - id: upload-release-asset
+              uses: actions/upload-release-asset@v1.0.1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ steps.create_release.outputs.upload_url }}
+                  asset_path: ./dist/big-slider-card.js
+                  asset_name: big-slider-card.js
+                  asset_content_type: text/javascript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
     push:
-        tags:
-            - 'v*'
+        branches:
+            - master
 
 jobs:
     build:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ hold_action:
 | border_radius     | string  | **Optional** | Border radius including units (CSS format)     | form theme          |
 | border_style      | string  | **Optional** | Border style (CSS format)                      | form theme          |
 | border_width      | string  | **Optional** | Border width (CSS format)                      | form theme          |
+| icon_padding      | string  | **Optional** | Padding around the icon (CSS format)           | form theme          |
 | colorize          | boolean | **Optional** | Colorize slider using entity color             | false               |
 | icon              | string  | **Optional** | Sets custom icon                               | entity icon         |
 | show_percentage   | boolean | **Optional** | Show percentage under entity name              | false               |
@@ -110,6 +111,7 @@ For more info about the rest of the action options see this page: [Actions - Hom
 --bsc-border-radius: var(--ha-card-border-radius);
 --bsc-border-style: var(--ha-card-border-style);
 --bsc-border-width: var(--ha-card-border-width);
+--bsc-icon-padding: 24px;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ hold_action:
 | border_radius     | string  | **Optional** | Border radius including units (CSS format)     | form theme          |
 | border_style      | string  | **Optional** | Border style (CSS format)                      | form theme          |
 | border_width      | string  | **Optional** | Border width (CSS format)                      | form theme          |
+| slider_opacity    | string  | **Optional** | Slider opacity (CSS format)                  | form theme          |
 | colorize          | boolean | **Optional** | Colorize slider using entity color             | false               |
 | icon              | string  | **Optional** | Sets custom icon                               | entity icon         |
 | show_percentage   | boolean | **Optional** | Show percentage under entity name              | false               |
@@ -110,6 +111,7 @@ For more info about the rest of the action options see this page: [Actions - Hom
 --bsc-border-radius: var(--ha-card-border-radius);
 --bsc-border-style: var(--ha-card-border-style);
 --bsc-border-width: var(--ha-card-border-width);
+--bsc-slider-opacity: 1;
 ```
 
 

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -46,6 +46,10 @@ export class BigSliderCard extends LitElement {
     return { type: 'custom:big-slider-card', entity: randomLight };
   }
 
+  static getConfigElement() {
+    return document.createElement("big-slider-card-editor");
+  }
+
   // life cycle
 
   public setConfig(config: Partial<BigSliderCardConfig>): void {

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -409,6 +409,7 @@ export class BigSliderCard extends LitElement {
     this._setStyleProperty('--bsc-border-style', this._config.border_style);
     this._setStyleProperty('--bsc-border-width', this._config.border_width);
     this._setStyleProperty('--bsc-height', this._config.height, (height) => `${height}px`);
+    this._setStyleProperty('--bsc-slider-opacity', this._config.slider_opacity);
 
     return html`
       <ha-card
@@ -480,6 +481,7 @@ export class BigSliderCard extends LitElement {
         --bsc-border-width: var(--ha-card-border-width);
         --bsc-height: var(--ha-card-height, 60px);
         --bsc-opacity: 1;
+        --bsc-slider-opacity: 0.3;
 
 
         display: flex;
@@ -521,7 +523,7 @@ export class BigSliderCard extends LitElement {
         height: 100%;
         position: absolute;
         background-color: var(--bsc-slider-color);
-        opacity: 0.3;
+        opacity: var(--bsc-slider-opacity);
         left: 0;
         top: 0;
         right: calc(100% - var(--bsc-percent));

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -409,6 +409,7 @@ export class BigSliderCard extends LitElement {
     this._setStyleProperty('--bsc-border-style', this._config.border_style);
     this._setStyleProperty('--bsc-border-width', this._config.border_width);
     this._setStyleProperty('--bsc-height', this._config.height, (height) => `${height}px`);
+    this._setStyleProperty('--bsc-icon-padding', this._config.icon_padding, (padding) => `${padding}px`);
 
     return html`
       <ha-card
@@ -480,6 +481,7 @@ export class BigSliderCard extends LitElement {
         --bsc-border-width: var(--ha-card-border-width);
         --bsc-height: var(--ha-card-height, 60px);
         --bsc-opacity: 1;
+        --bsc-icon-padding: 24px;
 
 
         display: flex;
@@ -541,7 +543,7 @@ export class BigSliderCard extends LitElement {
         position: absolute;
         top: 0;
         bottom: 0;
-        left: 24px;
+        left: var(--bsc-icon-padding);
         display: flex;
         justify-content: center;
         align-items: center;
@@ -557,7 +559,7 @@ export class BigSliderCard extends LitElement {
         display: flex;
         justify-content: flex-start;
         align-items: center;
-        padding: 0 24px 0 72px;
+        padding: 0 24px 0 calc(2 * var(--bsc-icon-padding) + 24px);
         box-sizing: border-box;
       }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,39 @@
+import { HomeAssistant } from "./ha-types";
+import { LitElement, TemplateResult, html } from "lit";
+import { BigSliderCardConfig } from "./types";
+import { fireEvent } from "custom-card-helpers";
+
+const SCHEMA = [
+  { name: "entity", selector: { entity: { domain: "light" } } },
+  { name: "name", selector: { text: {} } },
+  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
+  { name: "colorize", selector: { boolean: {} } },
+  { name: "show_percentage", selector: { boolean: {} } },
+  { name: "bold_text", selector: { boolean: {} } },
+  { name: "tap_action", selector: { "ui-action": {} } },
+  { name: "hold_action", selector: { "ui-action": {} } }
+]
+
+export class BigSliderCardEditor extends LitElement {
+  private _config?: BigSliderCardConfig;
+  private hass!: HomeAssistant;
+
+  protected setConfig(config: BigSliderCardConfig) {
+    this._config = config;
+  }
+
+  protected render(): TemplateResult | void {
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${SCHEMA}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(e: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: e.detail.value });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { BigSliderCard } from './big-slider-card';
 import { CARD_VERSION } from './const';
+import { BigSliderCardEditor } from './editor';
 import { localize } from './localize/localize';
 
 /* eslint no-console: 0 */
@@ -10,6 +11,7 @@ console.info(
 );
 
 customElements.define("big-slider-card", BigSliderCard);
+customElements.define("big-slider-card-editor", BigSliderCardEditor);
 
 (window as any).customCards = (window as any).customCards ?? [];
 (window as any).customCards.push({


### PR DESCRIPTION
I added another setting that allows one to set the opacity of the slider itself. This now defaults to 0.3 and cannot be changed without something like card-mod, which I guess is possible but I would prefer the setting on the card itself.

Edit: I just realised I didn't include a new built version, let me know if you want me to do that and I'll update the PR.