### PR TITLE
Tap to set

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ hold_action:
 | min               | number  | **Optional** | Minimum value for slider                       | `0`                 |
 | max               | number  | **Optional** | Maximum value for slider                       | `100`               |
 | immediate_update  | boolean | **Optional** | Update value while sliding every 300ms         | false               |
+| tap_to_set        | boolean | **Optional** | Set the value to the tapped position instead of running `tap_action` | false |
 | min_slide_time    | number  | **Optional** | Minimum time to prevent accidental changes (ms)| `0`                 |
 | hold_time         | number  | **Optional** | Hold gesture time (ms)                         | `600`               |
 | settle_time       | number  | **Optional** | Ignore updates after changing the value (ms)   | `3000`              |

--- a/dist/big-slider-card.js
+++ b/dist/big-slider-card.js
@@ -129,6 +129,7 @@ var e = Object.defineProperty, t = (t, n) => {
 		hold_time: "Hold time",
 		settle_time: "Settle time",
 		immediate_update: "Update while sliding",
+		tap_to_set: "Jump to tapped position",
 		background_color: "Background color",
 		height: "Height",
 		width: "Width",
@@ -1393,6 +1394,10 @@ var $ = class extends Z {
 			if (e.type === "pointercancel" && (clearTimeout(this.holdTimer), this._clearImmediateUpdate(), this._unpress(), this._startUpdates()), e.type === "pointerup") {
 				if (clearTimeout(this.holdTimer), this._clearImmediateUpdate(), this._unpress(), this._startUpdates(), this.isHold) return;
 				if (this.isTap) {
+					if (this._config.tap_to_set && this._setValueFromTap(e)) {
+						this._startUpdates(!0);
+						return;
+					}
 					this._handleTap();
 					return;
 				}
@@ -1704,6 +1709,10 @@ var $ = class extends Z {
 							selector: { boolean: {} }
 						},
 						{
+							name: "tap_to_set",
+							selector: { boolean: {} }
+						},
+						{
 							name: "tap_action",
 							selector: { ui_action: {} }
 						},
@@ -1726,6 +1735,7 @@ var $ = class extends Z {
 				hold_time: x("editor.labels.hold_time"),
 				settle_time: x("editor.labels.settle_time"),
 				immediate_update: x("editor.labels.immediate_update"),
+				tap_to_set: x("editor.labels.tap_to_set"),
 				background_color: x("editor.labels.background_color"),
 				height: x("editor.labels.height"),
 				width: x("editor.labels.width"),
@@ -1833,6 +1843,20 @@ var $ = class extends Z {
 	}
 	_updateContainerSize() {
 		return this.containerWidth = this.shadowRoot?.getElementById("container")?.clientWidth ?? 0, this.containerHeight = this.shadowRoot?.getElementById("container")?.clientHeight ?? 0, this._config.vertical ? this.containerHeight > 0 : this.containerWidth > 0;
+	}
+	_getTapFraction(e) {
+		let t = this.shadowRoot?.getElementById("container");
+		if (!t) return null;
+		let n = t.getBoundingClientRect(), r = this._config.vertical ? n.height : n.width;
+		if (!(r > 0)) return null;
+		let i = this._config.vertical ? n.bottom - e.clientY : e.clientX - n.left;
+		return Math.max(0, Math.min(1, i / r));
+	}
+	_setValueFromTap(e) {
+		let t = this._getTapFraction(e);
+		if (t === null) return !1;
+		let n = this._getRange();
+		return this.currentValue = this._usesRangeSlider() ? n.min + (n.max - n.min) * t : 100 * t, this._checklimits(), this._resetTrack(), this._updateSlider(), this._setValue(), !0;
 	}
 	_getDragValueDelta(e, t, n) {
 		return t <= 0 ? 0 : this._usesRangeSlider() ? (n.max - n.min) * e / t : 100 * e / t;

--- a/dist/big-slider-card.js
+++ b/dist/big-slider-card.js
@@ -1388,7 +1388,9 @@ var $ = class extends Z {
 				"pointermove",
 				"pointerup"
 			].includes(e.type) && this._updateValue(), e.type === "pointermove") {
-				if (this.isHold || this.isTap && Math.abs(t.relativeX) < 5 && Math.abs(t.relativeY) < 5) return;
+				if (this.isHold) return;
+				let n = e.pointerType === "mouse" ? 5 : 10;
+				if (this.isTap && Math.abs(t.relativeX) < n && Math.abs(t.relativeY) < n) return;
 				this.isTap = !1, clearTimeout(this.holdTimer), this._stopUpdates(), this._scheduleImmediateUpdate();
 			}
 			if (e.type === "pointercancel" && (clearTimeout(this.holdTimer), this._clearImmediateUpdate(), this._unpress(), this._startUpdates()), e.type === "pointerup") {

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -3,7 +3,7 @@ import { SlideGesture, type SlideGestureEvent } from '@nicufarmache/slide-gestur
 import { HassEntity } from "home-assistant-js-websocket";
 import { HomeAssistant } from './ha-types';
 import type { BigSliderCardConfig, MousePos } from './types';
-import { DEFAULT_CONFIG, SUPPORTED_DOMAINS, TAP_THRESHOLD } from './const';
+import { DEFAULT_CONFIG, SUPPORTED_DOMAINS, TAP_THRESHOLD, TOUCH_TAP_THRESHOLD } from './const';
 import { localize } from './localize/localize';
 import { state } from 'lit/decorators.js';
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -522,7 +522,8 @@ export class BigSliderCard extends LitElement {
 
     if (evt.type === 'pointermove') {
       if (this.isHold) return;
-      if (this.isTap && (Math.abs(extra.relativeX) < TAP_THRESHOLD && Math.abs(extra.relativeY) < TAP_THRESHOLD))
+      const tapThreshold = evt.pointerType === 'mouse' ? TAP_THRESHOLD : TOUCH_TAP_THRESHOLD;
+      if (this.isTap && (Math.abs(extra.relativeX) < tapThreshold && Math.abs(extra.relativeY) < tapThreshold))
         return;
       this.isTap = false;
       clearTimeout(this.holdTimer);

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -317,6 +317,10 @@ export class BigSliderCard extends LitElement {
               name: 'immediate_update',
               selector: { boolean: {} },
             },
+            {
+              name: 'tap_to_set',
+              selector: { boolean: {} },
+            },
             { name: 'tap_action', selector: { ui_action: {} } },
             { name: 'hold_action', selector: { ui_action: {} } },
           ],
@@ -335,6 +339,7 @@ export class BigSliderCard extends LitElement {
           hold_time: localize('editor.labels.hold_time'),
           settle_time: localize('editor.labels.settle_time'),
           immediate_update: localize('editor.labels.immediate_update'),
+          tap_to_set: localize('editor.labels.tap_to_set'),
           background_color: localize('editor.labels.background_color'),
           height: localize('editor.labels.height'),
           width: localize('editor.labels.width'),
@@ -541,6 +546,10 @@ export class BigSliderCard extends LitElement {
       if (this.isHold) return;
 
       if (this.isTap) {
+        if (this._config.tap_to_set && this._setValueFromTap(evt)) {
+          this._startUpdates(true);
+          return;
+        }
         this._handleTap();
         return;
       }
@@ -575,6 +584,41 @@ export class BigSliderCard extends LitElement {
     this.containerWidth = this.shadowRoot?.getElementById('container')?.clientWidth ?? 0;
     this.containerHeight = this.shadowRoot?.getElementById('container')?.clientHeight ?? 0;
     return this._config.vertical ? this.containerHeight > 0 : this.containerWidth > 0;
+  }
+
+  /// Fraction of the track the pointer sits at, 0 at the low end and 1 at the
+  /// high end. Vertical sliders fill upwards, so they measure from the bottom.
+  /// Returns null when the track has no measurable size.
+  _getTapFraction(evt: PointerEvent): number | null {
+    const container = this.shadowRoot?.getElementById('container');
+    if (!container) return null;
+
+    const rect = container.getBoundingClientRect();
+    const size = this._config.vertical ? rect.height : rect.width;
+    if (!(size > 0)) return null;
+
+    const offset = this._config.vertical ? rect.bottom - evt.clientY : evt.clientX - rect.left;
+    return Math.max(0, Math.min(1, offset / size));
+  }
+
+  /// Jump straight to the tapped position. Unlike a drag - which is relative to
+  /// where the gesture started - this maps the absolute pointer position onto
+  /// the range. Returns false when the position could not be measured, so the
+  /// caller can fall back to the configured tap_action.
+  _setValueFromTap(evt: PointerEvent): boolean {
+    const fraction = this._getTapFraction(evt);
+    if (fraction === null) return false;
+
+    const range = this._getRange();
+    this.currentValue = this._usesRangeSlider()
+      ? range.min + (range.max - range.min) * fraction
+      : 100 * fraction;
+
+    this._checklimits();
+    this._resetTrack();
+    this._updateSlider();
+    this._setValue();
+    return true;
   }
 
   _getDragValueDelta(delta: number, size: number, range: SliderRange): number {

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,6 +6,9 @@ export const SETTLE_TIME = 3000;
 export const HOLD_TIME = 600;
 export const MIN_SLIDE_TIME = 0;
 export const TAP_THRESHOLD = 5;
+// Fingers wobble far more than a mouse does, so a touch or pen gesture needs
+// more slack before it counts as a drag. Roughly matches browser touch slop.
+export const TOUCH_TAP_THRESHOLD = 10;
 export const MIN = 0;
 export const MAX = 100;
 export const SUPPORTED_DOMAINS = [

--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -41,6 +41,7 @@
       "hold_time": "Hold time",
       "settle_time": "Settle time",
       "immediate_update": "Update while sliding",
+      "tap_to_set": "Jump to tapped position",
       "background_color": "Background color",
       "height": "Height",
       "width": "Width",

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface BigSliderCardConfig extends LovelaceCardConfig {
   no_scale?: boolean;
   no_transition_animation?: boolean;
   immediate_update?: boolean;
+  tap_to_set?: boolean;
   vertical?: boolean;
   min: number;
   max: number;

--- a/tests/actions-lifecycle.test.ts
+++ b/tests/actions-lifecycle.test.ts
@@ -86,6 +86,42 @@ describe('actions and lifecycle', () => {
     card._handlePointer(new PointerEvent('pointerup', { clientX, clientY }), extra);
   };
 
+  const wobblyTap = (card: BigSliderCard, pointerType: string, wobble: number): void => {
+    const at = (dx: number) => ({ relativeX: dx, relativeY: 0 }) as SlideGestureEvent;
+    card._handlePointer(new PointerEvent('pointerdown', { clientX: 100, clientY: 25, pointerType }), at(0));
+    card._handlePointer(new PointerEvent('pointermove', {
+      clientX: 100 + wobble, clientY: 25, pointerType,
+    }), at(wobble));
+    card._handlePointer(new PointerEvent('pointerup', {
+      clientX: 100 + wobble, clientY: 25, pointerType,
+    }), at(wobble));
+  };
+
+  it('keeps a wobbly touch gesture a tap', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card } = createCard(entity, { tap_to_set: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    // 8px of finger wobble: past the mouse threshold, inside the touch one
+    wobblyTap(card, 'touch', 8);
+
+    expect(getCurrentValue(card)).toBeCloseTo(54);
+  });
+
+  it('treats the same movement from a mouse as a drag', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card } = createCard(entity, { tap_to_set: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    wobblyTap(card, 'mouse', 8);
+
+    // Relative drag from 100%, so it stays pinned at the top rather than
+    // jumping to the pointer position.
+    expect(getCurrentValue(card)).toBeCloseTo(100);
+  });
+
   it('sets the value from the tap position when tap_to_set is enabled', async () => {
     const entity = createEntity('light.test', 'on', { brightness: 255 });
     const { card, callService } = createCard(entity, { tap_to_set: true });

--- a/tests/actions-lifecycle.test.ts
+++ b/tests/actions-lifecycle.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createCard, createEntity, mount } from './fixtures';
+import type { SlideGestureEvent } from '@nicufarmache/slide-gesture';
+import type { BigSliderCard } from '../src/big-slider-card';
+import { createCard, createEntity, getCurrentValue, mount } from './fixtures';
 
 describe('actions and lifecycle', () => {
   afterEach(() => {
@@ -68,6 +70,86 @@ describe('actions and lifecycle', () => {
 
     card.remove();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  const stubContainerRect = (card: BigSliderCard, rect: Partial<DOMRect>): void => {
+    const container = card.shadowRoot!.getElementById('container')!;
+    container.getBoundingClientRect = () => ({
+      left: 0, top: 0, right: 200, bottom: 50, width: 200, height: 50, x: 0, y: 0,
+      toJSON: () => ({}), ...rect,
+    }) as DOMRect;
+  };
+
+  const tap = (card: BigSliderCard, clientX: number, clientY: number): void => {
+    const extra = { relativeX: 0, relativeY: 0 } as SlideGestureEvent;
+    card._handlePointer(new PointerEvent('pointerdown', { clientX, clientY }), extra);
+    card._handlePointer(new PointerEvent('pointerup', { clientX, clientY }), extra);
+  };
+
+  it('sets the value from the tap position when tap_to_set is enabled', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card, callService } = createCard(entity, { tap_to_set: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    tap(card, 150, 25);
+
+    expect(getCurrentValue(card)).toBeCloseTo(75);
+    expect(callService).toHaveBeenCalledWith('light', 'turn_on', expect.objectContaining({
+      entity_id: 'light.test', brightness: Math.round(75 / 100 * 255),
+    }));
+  });
+
+  it('measures the tap position from the bottom when vertical', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card } = createCard(entity, { tap_to_set: true, vertical: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    tap(card, 30, 40);
+
+    // 10px above the bottom of a 50px tall slider
+    expect(getCurrentValue(card)).toBeCloseTo(20);
+  });
+
+  it('maps the tap position into the entity range', async () => {
+    const entity = createEntity('number.test', '5', { min: 10, max: 20, step: 1 });
+    const { card } = createCard(entity, { tap_to_set: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    tap(card, 50, 25);
+
+    expect(getCurrentValue(card)).toBeCloseTo(12.5);
+  });
+
+  it('clamps taps outside the slider bounds', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card } = createCard(entity, { tap_to_set: true });
+    await mount(card);
+    stubContainerRect(card, {});
+
+    tap(card, -40, 25);
+    expect(getCurrentValue(card)).toBeCloseTo(0);
+
+    tap(card, 320, 25);
+    expect(getCurrentValue(card)).toBeCloseTo(100);
+  });
+
+  it('keeps dispatching the tap action when tap_to_set is disabled', async () => {
+    const entity = createEntity('light.test', 'on', { brightness: 255 });
+    const { card, callService } = createCard(entity);
+    await mount(card);
+    stubContainerRect(card, {});
+    const actions: string[] = [];
+    card.addEventListener('hass-action', event => {
+      actions.push((event as CustomEvent).detail.action);
+    });
+
+    tap(card, 150, 25);
+
+    expect(actions).toEqual(['tap']);
+    expect(callService).not.toHaveBeenCalled();
   });
 
   it('blocks the context menu', () => {


### PR DESCRIPTION
## Summary

I wanted to be able to tap on a spot on the slider and jump to that value

## Acceptance criteria

- [x] Tapping or clicking to a spot on the slider jumps to it
- [x] Sliding the slider works as it did previously (does not jump)

## Change area

- [x] Card behavior or gestures
- [ ] Home Assistant service calls
- [ ] Configuration or editor schema
- [ ] Rendering or styling
- [ ] Localization
- [ ] Documentation only
- [ ] Release or generated bundle

## Verification

- [x] Added or updated regression tests
- [x] Ran relevant focused tests
- [x] Ran `npm run check`
- [x] Confirmed `dist/big-slider-card.js` was generated rather than hand-edited
- [x] Reviewed the final diff for unrelated changes

For visible changes:

- [x] Checked the light preview
- [x] Checked the dark preview
- [x] Checked horizontal and vertical layouts when applicable

## Compatibility and risk

Should have no effect unless `tap_to_set` is added
