### PR TITLE
Scale colour temp and hue sliders to their real ranges

### DIFF
--- a/dist/big-slider-card.js
+++ b/dist/big-slider-card.js
@@ -57,7 +57,7 @@ var e = Object.defineProperty, t = (t, n) => {
 			totalY: this.#a
 		}), this.#e.releasePointerCapture(e.pointerId), this.#f());
 	}
-}, r = "1.2.9", i = "brightness", a = 3e3, o = [
+}, r = "1.2.9", i = "brightness", a = 3e3, o = 2200, s = 6500, c = [
 	"light",
 	"number",
 	"input_number",
@@ -68,7 +68,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	"water_heater",
 	"valve",
 	"media_player"
-], s = {
+], l = {
 	type: "custom:big-slider-card",
 	attribute: i,
 	tap_action: {
@@ -81,14 +81,14 @@ var e = Object.defineProperty, t = (t, n) => {
 	min_slide_time: 0,
 	min: 0,
 	max: 100
-}, c = /* @__PURE__ */ t({
-	card: () => te,
-	common: () => l,
-	default: () => ne,
-	editor: () => u,
-	errors: () => d,
-	preview: () => ee
-}), l = {
+}, u = /* @__PURE__ */ t({
+	card: () => re,
+	common: () => d,
+	default: () => ie,
+	editor: () => ee,
+	errors: () => te,
+	preview: () => ne
+}), d = {
 	version: "Version",
 	invalid_configuration: "Invalid configuration",
 	show_warning: "Show Warning",
@@ -96,7 +96,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entity not available",
 	on: "On",
 	off: "Off"
-}, u = {
+}, ee = {
 	sections: {
 		display: "Display Options",
 		styling: "Custom Styling",
@@ -147,26 +147,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Border style",
 		border_width: "Border width"
 	}
-}, d = {
+}, te = {
 	light_domain_only: "Specify an entity from within the light domain",
 	unsupported_domain: "Specify a supported slider entity"
-}, ee = { example_light: "Example Light" }, te = {
+}, ne = { example_light: "Example Light" }, re = {
 	name: "Big Slider Card",
 	description: "Big slider card for light entities."
-}, ne = {
-	common: l,
-	editor: u,
-	errors: d,
-	preview: ee,
-	card: te
-}, re = /* @__PURE__ */ t({
-	card: () => ce,
-	common: () => ie,
-	default: () => le,
-	editor: () => ae,
-	errors: () => oe,
-	preview: () => se
-}), ie = {
+}, ie = {
+	common: d,
+	editor: ee,
+	errors: te,
+	preview: ne,
+	card: re
+}, ae = /* @__PURE__ */ t({
+	card: () => ue,
+	common: () => oe,
+	default: () => de,
+	editor: () => se,
+	errors: () => ce,
+	preview: () => le
+}), oe = {
 	version: "Version",
 	invalid_configuration: "Ungültige Konfiguration",
 	show_warning: "Warnung anzeigen",
@@ -174,7 +174,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entität nicht verfügbar",
 	on: "An",
 	off: "Aus"
-}, ae = {
+}, se = {
 	sections: {
 		display: "Anzeigeoptionen",
 		styling: "Benutzerdefiniertes Styling",
@@ -225,26 +225,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Rahmenstil",
 		border_width: "Rahmenbreite"
 	}
-}, oe = {
+}, ce = {
 	light_domain_only: "Gib eine Entität aus der light-Domain an",
 	unsupported_domain: "Gib eine unterstützte Schieberegler-Entität an"
-}, se = { example_light: "Beispiellampe" }, ce = {
+}, le = { example_light: "Beispiellampe" }, ue = {
 	name: "Big Slider Card",
 	description: "Große Schiebereglerkarte für Lichtentitäten."
-}, le = {
-	common: ie,
-	editor: ae,
-	errors: oe,
-	preview: se,
-	card: ce
-}, ue = /* @__PURE__ */ t({
-	card: () => he,
-	common: () => de,
-	default: () => ge,
-	editor: () => fe,
-	errors: () => pe,
-	preview: () => me
-}), de = {
+}, de = {
+	common: oe,
+	editor: se,
+	errors: ce,
+	preview: le,
+	card: ue
+}, fe = /* @__PURE__ */ t({
+	card: () => _e,
+	common: () => pe,
+	default: () => ve,
+	editor: () => me,
+	errors: () => he,
+	preview: () => ge
+}), pe = {
 	version: "Versión",
 	invalid_configuration: "Configuración no válida",
 	show_warning: "Mostrar advertencia",
@@ -252,7 +252,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entidad no disponible",
 	on: "Encendido",
 	off: "Apagado"
-}, fe = {
+}, me = {
 	sections: {
 		display: "Opciones de visualización",
 		styling: "Estilo personalizado",
@@ -303,26 +303,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Estilo del borde",
 		border_width: "Anchura del borde"
 	}
-}, pe = {
+}, he = {
 	light_domain_only: "Especifica una entidad del dominio light",
 	unsupported_domain: "Especifica una entidad compatible con el control deslizante"
-}, me = { example_light: "Luz de ejemplo" }, he = {
+}, ge = { example_light: "Luz de ejemplo" }, _e = {
 	name: "Big Slider Card",
 	description: "Tarjeta deslizante grande para entidades de luz."
-}, ge = {
-	common: de,
-	editor: fe,
-	errors: pe,
-	preview: me,
-	card: he
-}, _e = /* @__PURE__ */ t({
-	card: () => Se,
-	common: () => ve,
-	default: () => Ce,
-	editor: () => ye,
-	errors: () => be,
-	preview: () => xe
-}), ve = {
+}, ve = {
+	common: pe,
+	editor: me,
+	errors: he,
+	preview: ge,
+	card: _e
+}, ye = /* @__PURE__ */ t({
+	card: () => Ce,
+	common: () => be,
+	default: () => we,
+	editor: () => xe,
+	errors: () => f,
+	preview: () => Se
+}), be = {
 	version: "Version",
 	invalid_configuration: "Configuration invalide",
 	show_warning: "Afficher l'avertissement",
@@ -330,7 +330,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entité non disponible",
 	on: "Allumé",
 	off: "Éteint"
-}, ye = {
+}, xe = {
 	sections: {
 		display: "Options d'affichage",
 		styling: "Style personnalisé",
@@ -381,26 +381,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Style de bordure",
 		border_width: "Largeur de bordure"
 	}
-}, be = {
+}, f = {
 	light_domain_only: "Spécifiez une entité du domaine light",
 	unsupported_domain: "Spécifiez une entité compatible avec le curseur"
-}, xe = { example_light: "Lumière d'exemple" }, Se = {
+}, Se = { example_light: "Lumière d'exemple" }, Ce = {
 	name: "Big Slider Card",
 	description: "Grande carte de curseur pour les entités lumière."
-}, Ce = {
-	common: ve,
-	editor: ye,
-	errors: be,
-	preview: xe,
-	card: Se
-}, we = /* @__PURE__ */ t({
-	card: () => ke,
-	common: () => Te,
-	default: () => Ae,
-	editor: () => Ee,
-	errors: () => De,
-	preview: () => Oe
-}), Te = {
+}, we = {
+	common: be,
+	editor: xe,
+	errors: f,
+	preview: Se,
+	card: Ce
+}, Te = /* @__PURE__ */ t({
+	card: () => Ae,
+	common: () => Ee,
+	default: () => je,
+	editor: () => De,
+	errors: () => Oe,
+	preview: () => ke
+}), Ee = {
 	version: "Versione",
 	invalid_configuration: "Configurazione non valida",
 	show_warning: "Mostra avviso",
@@ -408,7 +408,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entità non disponibile",
 	on: "Acceso",
 	off: "Spento"
-}, Ee = {
+}, De = {
 	sections: {
 		display: "Opzioni di visualizzazione",
 		styling: "Stile personalizzato",
@@ -459,26 +459,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Stile bordo",
 		border_width: "Spessore bordo"
 	}
-}, De = {
+}, Oe = {
 	light_domain_only: "Specifica un'entità del dominio light",
 	unsupported_domain: "Specifica un'entità supportata dal cursore"
-}, Oe = { example_light: "Luce di esempio" }, ke = {
+}, ke = { example_light: "Luce di esempio" }, Ae = {
 	name: "Big Slider Card",
 	description: "Scheda con cursore grande per entità luce."
-}, Ae = {
-	common: Te,
-	editor: Ee,
-	errors: De,
-	preview: Oe,
-	card: ke
-}, je = /* @__PURE__ */ t({
-	card: () => Ie,
-	common: () => Me,
-	default: () => Le,
-	editor: () => Ne,
-	errors: () => Pe,
-	preview: () => Fe
-}), Me = {
+}, je = {
+	common: Ee,
+	editor: De,
+	errors: Oe,
+	preview: ke,
+	card: Ae
+}, Me = /* @__PURE__ */ t({
+	card: () => h,
+	common: () => Ne,
+	default: () => Fe,
+	editor: () => Pe,
+	errors: () => p,
+	preview: () => m
+}), Ne = {
 	version: "Versie",
 	invalid_configuration: "Ongeldige configuratie",
 	show_warning: "Waarschuwing tonen",
@@ -486,7 +486,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entiteit niet beschikbaar",
 	on: "Aan",
 	off: "Uit"
-}, Ne = {
+}, Pe = {
 	sections: {
 		display: "Weergaveopties",
 		styling: "Aangepaste stijl",
@@ -537,26 +537,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Randstijl",
 		border_width: "Randbreedte"
 	}
-}, Pe = {
+}, p = {
 	light_domain_only: "Geef een entiteit uit het light-domein op",
 	unsupported_domain: "Geef een ondersteunde schuifregelaar-entiteit op"
-}, Fe = { example_light: "Voorbeeldlamp" }, Ie = {
+}, m = { example_light: "Voorbeeldlamp" }, h = {
 	name: "Big Slider Card",
 	description: "Grote schuifregelaar-kaart voor lichtentiteiten."
-}, Le = {
-	common: Me,
-	editor: Ne,
-	errors: Pe,
-	preview: Fe,
-	card: Ie
-}, Re = /* @__PURE__ */ t({
-	card: () => Ue,
-	common: () => ze,
-	default: () => We,
-	editor: () => Be,
-	errors: () => Ve,
-	preview: () => He
-}), ze = {
+}, Fe = {
+	common: Ne,
+	editor: Pe,
+	errors: p,
+	preview: m,
+	card: h
+}, Ie = /* @__PURE__ */ t({
+	card: () => b,
+	common: () => g,
+	default: () => Le,
+	editor: () => _,
+	errors: () => v,
+	preview: () => y
+}), g = {
 	version: "Wersja",
 	invalid_configuration: "Nieprawidłowa konfiguracja",
 	show_warning: "Pokaż ostrzeżenie",
@@ -564,7 +564,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Encja niedostępna",
 	on: "Włączone",
 	off: "Wyłączone"
-}, Be = {
+}, _ = {
 	sections: {
 		display: "Opcje wyświetlania",
 		styling: "Niestandardowy styl",
@@ -615,26 +615,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Styl obramowania",
 		border_width: "Szerokość obramowania"
 	}
-}, Ve = {
+}, v = {
 	light_domain_only: "Podaj encję z domeny light",
 	unsupported_domain: "Podaj obsługiwaną encję suwaka"
-}, He = { example_light: "Przykładowe światło" }, Ue = {
+}, y = { example_light: "Przykładowe światło" }, b = {
 	name: "Big Slider Card",
 	description: "Duża karta suwaka dla encji światła."
-}, We = {
-	common: ze,
-	editor: Be,
-	errors: Ve,
-	preview: He,
-	card: Ue
-}, Ge = /* @__PURE__ */ t({
-	card: () => g,
-	common: () => f,
-	default: () => Ke,
-	editor: () => p,
-	errors: () => m,
-	preview: () => h
-}), f = {
+}, Le = {
+	common: g,
+	editor: _,
+	errors: v,
+	preview: y,
+	card: b
+}, Re = /* @__PURE__ */ t({
+	card: () => Ue,
+	common: () => ze,
+	default: () => We,
+	editor: () => Be,
+	errors: () => Ve,
+	preview: () => He
+}), ze = {
 	version: "Versão",
 	invalid_configuration: "Configuração inválida",
 	show_warning: "Mostrar aviso",
@@ -642,7 +642,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entidade não disponível",
 	on: "Ligado",
 	off: "Desligado"
-}, p = {
+}, Be = {
 	sections: {
 		display: "Opções de exibição",
 		styling: "Estilo personalizado",
@@ -693,26 +693,26 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Estilo da borda",
 		border_width: "Largura da borda"
 	}
-}, m = {
+}, Ve = {
 	light_domain_only: "Especifique uma entidade do domínio light",
 	unsupported_domain: "Especifique uma entidade compatível com o controle deslizante"
-}, h = { example_light: "Luz de exemplo" }, g = {
+}, He = { example_light: "Luz de exemplo" }, Ue = {
 	name: "Big Slider Card",
 	description: "Cartão deslizante grande para entidades de luz."
-}, Ke = {
-	common: f,
-	editor: p,
-	errors: m,
-	preview: h,
-	card: g
-}, qe = /* @__PURE__ */ t({
-	card: () => Ye,
-	common: () => _,
-	default: () => Xe,
-	editor: () => v,
-	errors: () => y,
-	preview: () => Je
-}), _ = {
+}, We = {
+	common: ze,
+	editor: Be,
+	errors: Ve,
+	preview: He,
+	card: Ue
+}, Ge = /* @__PURE__ */ t({
+	card: () => Xe,
+	common: () => Ke,
+	default: () => Ze,
+	editor: () => qe,
+	errors: () => Je,
+	preview: () => Ye
+}), Ke = {
 	version: "Versiunea",
 	invalid_configuration: "Configurație invalidă",
 	show_warning: "Show Warning",
@@ -720,7 +720,7 @@ var e = Object.defineProperty, t = (t, n) => {
 	no_entity: "Entitatea nu e disponibilă",
 	on: "Pornit",
 	off: "Oprit"
-}, v = {
+}, qe = {
 	sections: {
 		display: "Opțiuni de afișare",
 		styling: "Stilizare personalizată",
@@ -771,75 +771,75 @@ var e = Object.defineProperty, t = (t, n) => {
 		border_style: "Stil chenar",
 		border_width: "Lățime chenar"
 	}
-}, y = {
+}, Je = {
 	light_domain_only: "Specifică o entitate din domeniul light",
 	unsupported_domain: "Specifică o entitate suportată de glisor"
-}, Je = { example_light: "Lumină exemplu" }, Ye = {
+}, Ye = { example_light: "Lumină exemplu" }, Xe = {
 	name: "Big Slider Card",
 	description: "Card cu glisor mare pentru entități de lumină."
-}, Xe = {
-	common: _,
-	editor: v,
-	errors: y,
-	preview: Je,
-	card: Ye
-}, b = {
-	en: c,
-	de: re,
-	es: ue,
-	fr: _e,
-	it: we,
-	nl: je,
-	pl: Re,
-	pt: Ge,
-	ro: qe
+}, Ze = {
+	common: Ke,
+	editor: qe,
+	errors: Je,
+	preview: Ye,
+	card: Xe
+}, x = {
+	en: u,
+	de: ae,
+	es: fe,
+	fr: ye,
+	it: Te,
+	nl: Me,
+	pl: Ie,
+	pt: Re,
+	ro: Ge
 };
-function x(e, t = "", n = "") {
+function S(e, t = "", n = "") {
 	let r = (localStorage.getItem("selectedLanguage") || "en").replace(/['"]+/g, "").replace("-", "_"), i;
 	try {
-		i = e.split(".").reduce((e, t) => e[t], b[r]);
+		i = e.split(".").reduce((e, t) => e[t], x[r]);
 	} catch {
-		i = e.split(".").reduce((e, t) => e[t], b.en);
+		i = e.split(".").reduce((e, t) => e[t], x.en);
 	}
-	return i === void 0 && (i = e.split(".").reduce((e, t) => e[t], b.en)), t !== "" && n !== "" && (i = i.replace(t, n)), i;
+	return i === void 0 && (i = e.split(".").reduce((e, t) => e[t], x.en)), t !== "" && n !== "" && (i = i.replace(t, n)), i;
 }
 //#endregion
 //#region node_modules/@lit/reactive-element/css-tag.js
-var S = globalThis, C = S.ShadowRoot && (S.ShadyCSS === void 0 || S.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, w = Symbol(), Ze = /* @__PURE__ */ new WeakMap(), Qe = class {
+var C = globalThis, w = C.ShadowRoot && (C.ShadyCSS === void 0 || C.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype, T = Symbol(), Qe = /* @__PURE__ */ new WeakMap(), $e = class {
 	constructor(e, t, n) {
-		if (this._$cssResult$ = !0, n !== w) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
+		if (this._$cssResult$ = !0, n !== T) throw Error("CSSResult is not constructable. Use `unsafeCSS` or `css` instead.");
 		this.cssText = e, this.t = t;
 	}
 	get styleSheet() {
 		let e = this.o, t = this.t;
-		if (C && e === void 0) {
+		if (w && e === void 0) {
 			let n = t !== void 0 && t.length === 1;
-			n && (e = Ze.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), n && Ze.set(t, e));
+			n && (e = Qe.get(t)), e === void 0 && ((this.o = e = new CSSStyleSheet()).replaceSync(this.cssText), n && Qe.set(t, e));
 		}
 		return e;
 	}
 	toString() {
 		return this.cssText;
 	}
-}, $e = (e) => new Qe(typeof e == "string" ? e : e + "", void 0, w), et = (e, ...t) => new Qe(e.length === 1 ? e[0] : t.reduce((t, n, r) => t + ((e) => {
+}, et = (e) => new $e(typeof e == "string" ? e : e + "", void 0, T), tt = (e, ...t) => new $e(e.length === 1 ? e[0] : t.reduce((t, n, r) => t + ((e) => {
 	if (!0 === e._$cssResult$) return e.cssText;
 	if (typeof e == "number") return e;
 	throw Error("Value passed to 'css' function must be a 'css' function result: " + e + ". Use 'unsafeCSS' to pass non-literal values, but take care to ensure page security.");
-})(n) + e[r + 1], e[0]), e, w), tt = (e, t) => {
-	if (C) e.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
+})(n) + e[r + 1], e[0]), e, T), nt = (e, t) => {
+	if (w) e.adoptedStyleSheets = t.map((e) => e instanceof CSSStyleSheet ? e : e.styleSheet);
 	else for (let n of t) {
-		let t = document.createElement("style"), r = S.litNonce;
+		let t = document.createElement("style"), r = C.litNonce;
 		r !== void 0 && t.setAttribute("nonce", r), t.textContent = n.cssText, e.appendChild(t);
 	}
-}, nt = C ? (e) => e : (e) => e instanceof CSSStyleSheet ? ((e) => {
+}, rt = w ? (e) => e : (e) => e instanceof CSSStyleSheet ? ((e) => {
 	let t = "";
 	for (let n of e.cssRules) t += n.cssText;
-	return $e(t);
-})(e) : e, { is: rt, defineProperty: it, getOwnPropertyDescriptor: at, getOwnPropertyNames: ot, getOwnPropertySymbols: st, getPrototypeOf: ct } = Object, T = globalThis, E = T.trustedTypes, lt = E ? E.emptyScript : "", ut = T.reactiveElementPolyfillSupport, D = (e, t) => e, O = {
+	return et(t);
+})(e) : e, { is: it, defineProperty: at, getOwnPropertyDescriptor: ot, getOwnPropertyNames: st, getOwnPropertySymbols: ct, getPrototypeOf: lt } = Object, E = globalThis, ut = E.trustedTypes, dt = ut ? ut.emptyScript : "", ft = E.reactiveElementPolyfillSupport, D = (e, t) => e, O = {
 	toAttribute(e, t) {
 		switch (t) {
 			case Boolean:
-				e = e ? lt : null;
+				e = e ? dt : null;
 				break;
 			case Object:
 			case Array: e = e == null ? e : JSON.stringify(e);
@@ -864,7 +864,7 @@ var S = globalThis, C = S.ShadowRoot && (S.ShadyCSS === void 0 || S.ShadyCSS.nat
 		}
 		return n;
 	}
-}, k = (e, t) => !rt(e, t), dt = {
+}, k = (e, t) => !it(e, t), pt = {
 	attribute: !0,
 	type: String,
 	converter: O,
@@ -872,7 +872,7 @@ var S = globalThis, C = S.ShadowRoot && (S.ShadyCSS === void 0 || S.ShadyCSS.nat
 	useDefault: !1,
 	hasChanged: k
 };
-Symbol.metadata ??= Symbol("metadata"), T.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
+Symbol.metadata ??= Symbol("metadata"), E.litPropertyMetadata ??= /* @__PURE__ */ new WeakMap();
 var A = class extends HTMLElement {
 	static addInitializer(e) {
 		this._$Ei(), (this.l ??= []).push(e);
@@ -880,14 +880,14 @@ var A = class extends HTMLElement {
 	static get observedAttributes() {
 		return this.finalize(), this._$Eh && [...this._$Eh.keys()];
 	}
-	static createProperty(e, t = dt) {
+	static createProperty(e, t = pt) {
 		if (t.state && (t.attribute = !1), this._$Ei(), this.prototype.hasOwnProperty(e) && ((t = Object.create(t)).wrapped = !0), this.elementProperties.set(e, t), !t.noAccessor) {
 			let n = Symbol(), r = this.getPropertyDescriptor(e, n, t);
-			r !== void 0 && it(this.prototype, e, r);
+			r !== void 0 && at(this.prototype, e, r);
 		}
 	}
 	static getPropertyDescriptor(e, t, n) {
-		let { get: r, set: i } = at(this.prototype, e) ?? {
+		let { get: r, set: i } = ot(this.prototype, e) ?? {
 			get() {
 				return this[t];
 			},
@@ -906,17 +906,17 @@ var A = class extends HTMLElement {
 		};
 	}
 	static getPropertyOptions(e) {
-		return this.elementProperties.get(e) ?? dt;
+		return this.elementProperties.get(e) ?? pt;
 	}
 	static _$Ei() {
 		if (this.hasOwnProperty(D("elementProperties"))) return;
-		let e = ct(this);
+		let e = lt(this);
 		e.finalize(), e.l !== void 0 && (this.l = [...e.l]), this.elementProperties = new Map(e.elementProperties);
 	}
 	static finalize() {
 		if (this.hasOwnProperty(D("finalized"))) return;
 		if (this.finalized = !0, this._$Ei(), this.hasOwnProperty(D("properties"))) {
-			let e = this.properties, t = [...ot(e), ...st(e)];
+			let e = this.properties, t = [...st(e), ...ct(e)];
 			for (let n of t) this.createProperty(n, e[n]);
 		}
 		let e = this[Symbol.metadata];
@@ -935,8 +935,8 @@ var A = class extends HTMLElement {
 		let t = [];
 		if (Array.isArray(e)) {
 			let n = new Set(e.flat(Infinity).reverse());
-			for (let e of n) t.unshift(nt(e));
-		} else e !== void 0 && t.push(nt(e));
+			for (let e of n) t.unshift(rt(e));
+		} else e !== void 0 && t.push(rt(e));
 		return t;
 	}
 	static _$Eu(e, t) {
@@ -962,7 +962,7 @@ var A = class extends HTMLElement {
 	}
 	createRenderRoot() {
 		let e = this.shadowRoot ?? this.attachShadow(this.constructor.shadowRootOptions);
-		return tt(e, this.constructor.elementStyles), e;
+		return nt(e, this.constructor.elementStyles), e;
 	}
 	connectedCallback() {
 		this.renderRoot ??= this.createRenderRoot(), this.enableUpdating(!0), this._$EO?.forEach((e) => e.hostConnected?.());
@@ -1057,16 +1057,16 @@ var A = class extends HTMLElement {
 	updated(e) {}
 	firstUpdated(e) {}
 };
-A.elementStyles = [], A.shadowRootOptions = { mode: "open" }, A[D("elementProperties")] = /* @__PURE__ */ new Map(), A[D("finalized")] = /* @__PURE__ */ new Map(), ut?.({ ReactiveElement: A }), (T.reactiveElementVersions ??= []).push("2.1.2");
+A.elementStyles = [], A.shadowRootOptions = { mode: "open" }, A[D("elementProperties")] = /* @__PURE__ */ new Map(), A[D("finalized")] = /* @__PURE__ */ new Map(), ft?.({ ReactiveElement: A }), (E.reactiveElementVersions ??= []).push("2.1.2");
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/property.js
-var ft = {
+var mt = {
 	attribute: !0,
 	type: String,
 	converter: O,
 	reflect: !1,
 	hasChanged: k
-}, pt = (e = ft, t, n) => {
+}, ht = (e = mt, t, n) => {
 	let { kind: r, metadata: i } = n, a = globalThis.litPropertyMetadata.get(i);
 	if (a === void 0 && globalThis.litPropertyMetadata.set(i, a = /* @__PURE__ */ new Map()), r === "setter" && ((e = Object.create(e)).wrapped = !0), a.set(n.name, e), r === "accessor") {
 		let { name: r } = n;
@@ -1089,8 +1089,8 @@ var ft = {
 	}
 	throw Error("Unsupported decorator location: " + r);
 };
-function mt(e) {
-	return (t, n) => typeof n == "object" ? pt(e, t, n) : ((e, t, n) => {
+function gt(e) {
+	return (t, n) => typeof n == "object" ? ht(e, t, n) : ((e, t, n) => {
 		let r = t.hasOwnProperty(n);
 		return t.constructor.createProperty(n, e), r ? Object.getOwnPropertyDescriptor(t, n) : void 0;
 	})(e, t, n);
@@ -1098,7 +1098,7 @@ function mt(e) {
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/state.js
 function j(e) {
-	return mt({
+	return gt({
 		...e,
 		state: !0,
 		attribute: !1
@@ -1106,49 +1106,49 @@ function j(e) {
 }
 //#endregion
 //#region node_modules/lit-html/lit-html.js
-var M = globalThis, ht = (e) => e, N = M.trustedTypes, gt = N ? N.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, _t = "$lit$", P = `lit$${Math.random().toFixed(9).slice(2)}$`, vt = "?" + P, yt = `<${vt}>`, F = document, I = () => F.createComment(""), L = (e) => e === null || typeof e != "object" && typeof e != "function", R = Array.isArray, bt = (e) => R(e) || typeof e?.[Symbol.iterator] == "function", z = "[ 	\n\f\r]", B = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, xt = /-->/g, St = />/g, V = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"), Ct = /'/g, wt = /"/g, Tt = /^(?:script|style|textarea|title)$/i, Et = ((e) => (t, ...n) => ({
+var M = globalThis, _t = (e) => e, N = M.trustedTypes, vt = N ? N.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, yt = "$lit$", P = `lit$${Math.random().toFixed(9).slice(2)}$`, bt = "?" + P, xt = `<${bt}>`, F = document, I = () => F.createComment(""), L = (e) => e === null || typeof e != "object" && typeof e != "function", R = Array.isArray, St = (e) => R(e) || typeof e?.[Symbol.iterator] == "function", z = "[ 	\n\f\r]", B = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, Ct = /-->/g, wt = />/g, V = RegExp(`>|${z}(?:([^\\s"'>=/]+)(${z}*=${z}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"), Tt = /'/g, Et = /"/g, Dt = /^(?:script|style|textarea|title)$/i, Ot = ((e) => (t, ...n) => ({
 	_$litType$: e,
 	strings: t,
 	values: n
-}))(1), H = Symbol.for("lit-noChange"), U = Symbol.for("lit-nothing"), Dt = /* @__PURE__ */ new WeakMap(), W = F.createTreeWalker(F, 129);
-function Ot(e, t) {
+}))(1), H = Symbol.for("lit-noChange"), U = Symbol.for("lit-nothing"), kt = /* @__PURE__ */ new WeakMap(), W = F.createTreeWalker(F, 129);
+function At(e, t) {
 	if (!R(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
-	return gt === void 0 ? t : gt.createHTML(t);
+	return vt === void 0 ? t : vt.createHTML(t);
 }
-var kt = (e, t) => {
+var jt = (e, t) => {
 	let n = e.length - 1, r = [], i, a = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = B;
 	for (let t = 0; t < n; t++) {
 		let n = e[t], s, c, l = -1, u = 0;
-		for (; u < n.length && (o.lastIndex = u, c = o.exec(n), c !== null);) u = o.lastIndex, o === B ? c[1] === "!--" ? o = xt : c[1] === void 0 ? c[2] === void 0 ? c[3] !== void 0 && (o = V) : (Tt.test(c[2]) && (i = RegExp("</" + c[2], "g")), o = V) : o = St : o === V ? c[0] === ">" ? (o = i ?? B, l = -1) : c[1] === void 0 ? l = -2 : (l = o.lastIndex - c[2].length, s = c[1], o = c[3] === void 0 ? V : c[3] === "\"" ? wt : Ct) : o === wt || o === Ct ? o = V : o === xt || o === St ? o = B : (o = V, i = void 0);
+		for (; u < n.length && (o.lastIndex = u, c = o.exec(n), c !== null);) u = o.lastIndex, o === B ? c[1] === "!--" ? o = Ct : c[1] === void 0 ? c[2] === void 0 ? c[3] !== void 0 && (o = V) : (Dt.test(c[2]) && (i = RegExp("</" + c[2], "g")), o = V) : o = wt : o === V ? c[0] === ">" ? (o = i ?? B, l = -1) : c[1] === void 0 ? l = -2 : (l = o.lastIndex - c[2].length, s = c[1], o = c[3] === void 0 ? V : c[3] === "\"" ? Et : Tt) : o === Et || o === Tt ? o = V : o === Ct || o === wt ? o = B : (o = V, i = void 0);
 		let d = o === V && e[t + 1].startsWith("/>") ? " " : "";
-		a += o === B ? n + yt : l >= 0 ? (r.push(s), n.slice(0, l) + _t + n.slice(l) + P + d) : n + P + (l === -2 ? t : d);
+		a += o === B ? n + xt : l >= 0 ? (r.push(s), n.slice(0, l) + yt + n.slice(l) + P + d) : n + P + (l === -2 ? t : d);
 	}
-	return [Ot(e, a + (e[n] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+	return [At(e, a + (e[n] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
 }, G = class e {
 	constructor({ strings: t, _$litType$: n }, r) {
 		let i;
 		this.parts = [];
-		let a = 0, o = 0, s = t.length - 1, c = this.parts, [l, u] = kt(t, n);
+		let a = 0, o = 0, s = t.length - 1, c = this.parts, [l, u] = jt(t, n);
 		if (this.el = e.createElement(l, r), W.currentNode = this.el.content, n === 2 || n === 3) {
 			let e = this.el.content.firstChild;
 			e.replaceWith(...e.childNodes);
 		}
 		for (; (i = W.nextNode()) !== null && c.length < s;) {
 			if (i.nodeType === 1) {
-				if (i.hasAttributes()) for (let e of i.getAttributeNames()) if (e.endsWith(_t)) {
+				if (i.hasAttributes()) for (let e of i.getAttributeNames()) if (e.endsWith(yt)) {
 					let t = u[o++], n = i.getAttribute(e).split(P), r = /([.?@])?(.*)/.exec(t);
 					c.push({
 						type: 1,
 						index: a,
 						name: r[2],
 						strings: n,
-						ctor: r[1] === "." ? jt : r[1] === "?" ? Mt : r[1] === "@" ? Nt : J
+						ctor: r[1] === "." ? Nt : r[1] === "?" ? Pt : r[1] === "@" ? Ft : J
 					}), i.removeAttribute(e);
 				} else e.startsWith(P) && (c.push({
 					type: 6,
 					index: a
 				}), i.removeAttribute(e));
-				if (Tt.test(i.tagName)) {
+				if (Dt.test(i.tagName)) {
 					let e = i.textContent.split(P), t = e.length - 1;
 					if (t > 0) {
 						i.textContent = N ? N.emptyScript : "";
@@ -1159,7 +1159,7 @@ var kt = (e, t) => {
 						i.append(e[t], I());
 					}
 				}
-			} else if (i.nodeType === 8) if (i.data === vt) c.push({
+			} else if (i.nodeType === 8) if (i.data === bt) c.push({
 				type: 2,
 				index: a
 			});
@@ -1183,7 +1183,7 @@ function K(e, t, n = e, r) {
 	let i = r === void 0 ? n._$Cl : n._$Co?.[r], a = L(t) ? void 0 : t._$litDirective$;
 	return i?.constructor !== a && (i?._$AO?.(!1), a === void 0 ? i = void 0 : (i = new a(e), i._$AT(e, n, r)), r === void 0 ? n._$Cl = i : (n._$Co ??= [])[r] = i), i !== void 0 && (t = K(e, i._$AS(e, t.values), i, r)), t;
 }
-var At = class {
+var Mt = class {
 	constructor(e, t) {
 		this._$AV = [], this._$AN = void 0, this._$AD = e, this._$AM = t;
 	}
@@ -1200,7 +1200,7 @@ var At = class {
 		for (; s !== void 0;) {
 			if (a === s.index) {
 				let t;
-				s.type === 2 ? t = new q(i, i.nextSibling, this, e) : s.type === 1 ? t = new s.ctor(i, s.name, s.strings, this, e) : s.type === 6 && (t = new Pt(i, this, e)), this._$AV.push(t), s = n[++o];
+				s.type === 2 ? t = new q(i, i.nextSibling, this, e) : s.type === 1 ? t = new s.ctor(i, s.name, s.strings, this, e) : s.type === 6 && (t = new It(i, this, e)), this._$AV.push(t), s = n[++o];
 			}
 			a !== s?.index && (i = W.nextNode(), a++);
 		}
@@ -1228,7 +1228,7 @@ var At = class {
 		return this._$AB;
 	}
 	_$AI(e, t = this) {
-		e = K(this, e, t), L(e) ? e === U || e == null || e === "" ? (this._$AH !== U && this._$AR(), this._$AH = U) : e !== this._$AH && e !== H && this._(e) : e._$litType$ === void 0 ? e.nodeType === void 0 ? bt(e) ? this.k(e) : this._(e) : this.T(e) : this.$(e);
+		e = K(this, e, t), L(e) ? e === U || e == null || e === "" ? (this._$AH !== U && this._$AR(), this._$AH = U) : e !== this._$AH && e !== H && this._(e) : e._$litType$ === void 0 ? e.nodeType === void 0 ? St(e) ? this.k(e) : this._(e) : this.T(e) : this.$(e);
 	}
 	O(e) {
 		return this._$AA.parentNode.insertBefore(e, this._$AB);
@@ -1240,16 +1240,16 @@ var At = class {
 		this._$AH !== U && L(this._$AH) ? this._$AA.nextSibling.data = e : this.T(F.createTextNode(e)), this._$AH = e;
 	}
 	$(e) {
-		let { values: t, _$litType$: n } = e, r = typeof n == "number" ? this._$AC(e) : (n.el === void 0 && (n.el = G.createElement(Ot(n.h, n.h[0]), this.options)), n);
+		let { values: t, _$litType$: n } = e, r = typeof n == "number" ? this._$AC(e) : (n.el === void 0 && (n.el = G.createElement(At(n.h, n.h[0]), this.options)), n);
 		if (this._$AH?._$AD === r) this._$AH.p(t);
 		else {
-			let e = new At(r, this), n = e.u(this.options);
+			let e = new Mt(r, this), n = e.u(this.options);
 			e.p(t), this.T(n), this._$AH = e;
 		}
 	}
 	_$AC(e) {
-		let t = Dt.get(e.strings);
-		return t === void 0 && Dt.set(e.strings, t = new G(e)), t;
+		let t = kt.get(e.strings);
+		return t === void 0 && kt.set(e.strings, t = new G(e)), t;
 	}
 	k(t) {
 		R(this._$AH) || (this._$AH = [], this._$AR());
@@ -1259,8 +1259,8 @@ var At = class {
 	}
 	_$AR(e = this._$AA.nextSibling, t) {
 		for (this._$AP?.(!1, !0, t); e !== this._$AB;) {
-			let t = ht(e).nextSibling;
-			ht(e).remove(), e = t;
+			let t = _t(e).nextSibling;
+			_t(e).remove(), e = t;
 		}
 	}
 	setConnected(e) {
@@ -1288,21 +1288,21 @@ var At = class {
 	j(e) {
 		e === U ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
 	}
-}, jt = class extends J {
+}, Nt = class extends J {
 	constructor() {
 		super(...arguments), this.type = 3;
 	}
 	j(e) {
 		this.element[this.name] = e === U ? void 0 : e;
 	}
-}, Mt = class extends J {
+}, Pt = class extends J {
 	constructor() {
 		super(...arguments), this.type = 4;
 	}
 	j(e) {
 		this.element.toggleAttribute(this.name, !!e && e !== U);
 	}
-}, Nt = class extends J {
+}, Ft = class extends J {
 	constructor(e, t, n, r, i) {
 		super(e, t, n, r, i), this.type = 5;
 	}
@@ -1314,7 +1314,7 @@ var At = class {
 	handleEvent(e) {
 		typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, e) : this._$AH.handleEvent(e);
 	}
-}, Pt = class {
+}, It = class {
 	constructor(e, t, n) {
 		this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = n;
 	}
@@ -1324,9 +1324,9 @@ var At = class {
 	_$AI(e) {
 		K(this, e);
 	}
-}, Ft = M.litHtmlPolyfillSupport;
-Ft?.(G, q), (M.litHtmlVersions ??= []).push("3.3.3");
-var It = (e, t, n) => {
+}, Lt = M.litHtmlPolyfillSupport;
+Lt?.(G, q), (M.litHtmlVersions ??= []).push("3.3.3");
+var Rt = (e, t, n) => {
 	let r = n?.renderBefore ?? t, i = r._$litPart$;
 	if (i === void 0) {
 		let e = n?.renderBefore ?? null;
@@ -1343,7 +1343,7 @@ var It = (e, t, n) => {
 	}
 	update(e) {
 		let t = this.render();
-		this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = It(t, this.renderRoot, this.renderOptions);
+		this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Rt(t, this.renderRoot, this.renderOptions);
 	}
 	connectedCallback() {
 		super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -1356,8 +1356,8 @@ var It = (e, t, n) => {
 	}
 };
 Z._$litElement$ = !0, Z.finalized = !0, X.litElementHydrateSupport?.({ LitElement: Z });
-var Lt = X.litElementPolyfillSupport;
-Lt?.({ LitElement: Z }), (X.litElementVersions ??= []).push("4.2.2");
+var zt = X.litElementPolyfillSupport;
+zt?.({ LitElement: Z }), (X.litElementVersions ??= []).push("4.2.2");
 //#endregion
 //#region \0@oxc-project+runtime@0.139.0/helpers/esm/decorate.js
 function Q(e, t, n, r) {
@@ -1370,7 +1370,7 @@ function Q(e, t, n, r) {
 //#region src/big-slider-card.ts
 var $ = class extends Z {
 	constructor(...e) {
-		super(...e), this._config = s, this.mouseStartPos = {
+		super(...e), this._config = l, this.mouseStartPos = {
 			x: 0,
 			y: 0
 		}, this.mousePos = {
@@ -1405,7 +1405,7 @@ var $ = class extends Z {
 		};
 	}
 	static getStubConfig(e, t) {
-		let n = t.filter((e) => o.includes(e.split(".")[0])).sort(), r = n[Math.floor(Math.random() * n.length)];
+		let n = t.filter((e) => c.includes(e.split(".")[0])).sort(), r = n[Math.floor(Math.random() * n.length)];
 		return {
 			type: "custom:big-slider-card",
 			...r ? { entity: r } : {}
@@ -1434,7 +1434,7 @@ var $ = class extends Z {
 				{
 					name: "entity",
 					required: !0,
-					selector: { entity: { domain: o } }
+					selector: { entity: { domain: c } }
 				},
 				{
 					name: "name",
@@ -1447,7 +1447,7 @@ var $ = class extends Z {
 				{
 					type: "expandable",
 					name: "display",
-					title: x("editor.sections.display"),
+					title: S("editor.sections.display"),
 					flatten: !0,
 					schema: [
 						{
@@ -1455,59 +1455,59 @@ var $ = class extends Z {
 							selector: { select: { options: [
 								{
 									value: "brightness",
-									label: x("editor.attributes.brightness")
+									label: S("editor.attributes.brightness")
 								},
 								{
 									value: "red",
-									label: x("editor.attributes.red")
+									label: S("editor.attributes.red")
 								},
 								{
 									value: "green",
-									label: x("editor.attributes.green")
+									label: S("editor.attributes.green")
 								},
 								{
 									value: "blue",
-									label: x("editor.attributes.blue")
+									label: S("editor.attributes.blue")
 								},
 								{
 									value: "hue",
-									label: x("editor.attributes.hue")
+									label: S("editor.attributes.hue")
 								},
 								{
 									value: "saturation",
-									label: x("editor.attributes.saturation")
+									label: S("editor.attributes.saturation")
 								},
 								{
 									value: "color_temp_kelvin",
-									label: x("editor.attributes.color_temp_kelvin")
+									label: S("editor.attributes.color_temp_kelvin")
 								},
 								{
 									value: "value",
-									label: x("editor.attributes.value")
+									label: S("editor.attributes.value")
 								},
 								{
 									value: "percentage",
-									label: x("editor.attributes.percentage")
+									label: S("editor.attributes.percentage")
 								},
 								{
 									value: "position",
-									label: x("editor.attributes.position")
+									label: S("editor.attributes.position")
 								},
 								{
 									value: "tilt_position",
-									label: x("editor.attributes.tilt_position")
+									label: S("editor.attributes.tilt_position")
 								},
 								{
 									value: "temperature",
-									label: x("editor.attributes.temperature")
+									label: S("editor.attributes.temperature")
 								},
 								{
 									value: "humidity",
-									label: x("editor.attributes.humidity")
+									label: S("editor.attributes.humidity")
 								},
 								{
 									value: "volume",
-									label: x("editor.attributes.volume")
+									label: S("editor.attributes.volume")
 								}
 							] } }
 						},
@@ -1536,7 +1536,7 @@ var $ = class extends Z {
 				{
 					type: "expandable",
 					name: "styling",
-					title: x("editor.sections.styling"),
+					title: S("editor.sections.styling"),
 					flatten: !0,
 					schema: [
 						{
@@ -1658,7 +1658,7 @@ var $ = class extends Z {
 				{
 					type: "expandable",
 					name: "behavior",
-					title: x("editor.sections.behavior"),
+					title: S("editor.sections.behavior"),
 					flatten: !0,
 					schema: [
 						{
@@ -1715,43 +1715,43 @@ var $ = class extends Z {
 				}
 			],
 			computeLabel: (e, t) => ({
-				colorize: x("editor.labels.colorize"),
-				show_percentage: x("editor.labels.show_percentage"),
-				show_icon_halo: x("editor.labels.show_icon_halo"),
-				bold_text: x("editor.labels.bold_text"),
-				no_scale: x("editor.labels.no_scale"),
-				no_transition_animation: x("editor.labels.no_transition_animation"),
-				vertical: x("editor.labels.vertical"),
-				min_slide_time: x("editor.labels.min_slide_time"),
-				hold_time: x("editor.labels.hold_time"),
-				settle_time: x("editor.labels.settle_time"),
-				immediate_update: x("editor.labels.immediate_update"),
-				background_color: x("editor.labels.background_color"),
-				height: x("editor.labels.height"),
-				width: x("editor.labels.width"),
-				text_color: x("editor.labels.text_color"),
-				icon_color: x("editor.labels.icon_color"),
-				icon_off_color: x("editor.labels.icon_off_color"),
-				constant_icon_color: x("editor.labels.constant_icon_color"),
-				icon_size: x("editor.labels.icon_size"),
-				icon_box_size: x("editor.labels.icon_box_size"),
-				slider_opacity: x("editor.labels.slider_opacity"),
-				use_alternative_slider_color: x("editor.labels.use_alternative_slider_color"),
-				text_size: x("editor.labels.text_size"),
-				border_color: x("editor.labels.border_color"),
-				border_radius: x("editor.labels.border_radius"),
-				border_style: x("editor.labels.border_style"),
-				border_width: x("editor.labels.border_width")
+				colorize: S("editor.labels.colorize"),
+				show_percentage: S("editor.labels.show_percentage"),
+				show_icon_halo: S("editor.labels.show_icon_halo"),
+				bold_text: S("editor.labels.bold_text"),
+				no_scale: S("editor.labels.no_scale"),
+				no_transition_animation: S("editor.labels.no_transition_animation"),
+				vertical: S("editor.labels.vertical"),
+				min_slide_time: S("editor.labels.min_slide_time"),
+				hold_time: S("editor.labels.hold_time"),
+				settle_time: S("editor.labels.settle_time"),
+				immediate_update: S("editor.labels.immediate_update"),
+				background_color: S("editor.labels.background_color"),
+				height: S("editor.labels.height"),
+				width: S("editor.labels.width"),
+				text_color: S("editor.labels.text_color"),
+				icon_color: S("editor.labels.icon_color"),
+				icon_off_color: S("editor.labels.icon_off_color"),
+				constant_icon_color: S("editor.labels.constant_icon_color"),
+				icon_size: S("editor.labels.icon_size"),
+				icon_box_size: S("editor.labels.icon_box_size"),
+				slider_opacity: S("editor.labels.slider_opacity"),
+				use_alternative_slider_color: S("editor.labels.use_alternative_slider_color"),
+				text_size: S("editor.labels.text_size"),
+				border_color: S("editor.labels.border_color"),
+				border_radius: S("editor.labels.border_radius"),
+				border_style: S("editor.labels.border_style"),
+				border_width: S("editor.labels.border_width")
 			})[e.name] || t(`ui.panel.lovelace.editor.card.generic.${e.name}`) || e.name
 		};
 	}
 	setConfig(e) {
-		if (!e) throw Error(x("common.invalid_configuration"));
+		if (!e) throw Error(S("common.invalid_configuration"));
 		let t = this._getDomain(e.entity);
-		if (t && !o.includes(t)) throw Error(x("errors.unsupported_domain"));
+		if (t && !c.includes(t)) throw Error(S("errors.unsupported_domain"));
 		let n = e.attribute ?? this._getDefaultAttribute(t), r = this._getAttributeDefaults(n, t);
 		this.customMin = e.min, this.customMax = e.max, this._config = {
-			...s,
+			...l,
 			attribute: n,
 			...r,
 			...e
@@ -1760,8 +1760,12 @@ var $ = class extends Z {
 	_getAttributeDefaults(e, t) {
 		switch (e) {
 			case "color_temp_kelvin": return {
-				min: 2200,
-				max: 6500
+				min: o,
+				max: s
+			};
+			case "hue": return {
+				min: 0,
+				max: 360
 			};
 			default: return {};
 		}
@@ -1780,7 +1784,7 @@ var $ = class extends Z {
 			case "climate":
 			case "water_heater": return "temperature";
 			case "humidifier": return "humidity";
-			default: return s.attribute;
+			default: return l.attribute;
 		}
 	}
 	set hass(e) {
@@ -1809,7 +1813,7 @@ var $ = class extends Z {
 		};
 	}
 	get _effectiveName() {
-		return this._config.name ? this._config.name : this._state ? this._state.attributes?.friendly_name ?? this._entity?.split(".")[1] ?? "" : x("preview.example_light");
+		return this._config.name ? this._config.name : this._state ? this._state.attributes?.friendly_name ?? this._entity?.split(".")[1] ?? "" : S("preview.example_light");
 	}
 	get _effectiveStatus() {
 		return this._state ? this._state.state : "on";
@@ -1917,7 +1921,7 @@ var $ = class extends Z {
 		} else e = "var(--bsc-off-color)";
 		let s = this?.shadowRoot?.getElementById("percentage");
 		if (o === "light" && !r) {
-			let e = i ? this._hass && typeof this._hass.formatEntityState == "function" ? this._hass.formatEntityState(i) : i.state : x("common.off");
+			let e = i ? this._hass && typeof this._hass.formatEntityState == "function" ? this._hass.formatEntityState(i) : i.state : S("common.off");
 			s && (s.innerText = e);
 		}
 		this.style.setProperty("--bsc-entity-color", e), this.style.setProperty("--bsc-brightness", t), this.style.setProperty("--bsc-brightness-ui", n), this.style.setProperty("--bsc-icon-brightness", this._config.constant_icon_color === !0 ? "100%" : n), this.style.setProperty("--bsc-icon-background", this._config.show_icon_halo === !0 ? "color-mix(in srgb, var(--bsc-icon-color, var(--bsc-entity-color)) 20%, transparent)" : "transparent"), this.style.setProperty("--bsc-icon-off-background", this._config.show_icon_halo === !0 ? "color-mix(in srgb, var(--bsc-off-color) 20%, transparent)" : "transparent"), r && this._config.icon_color ? this.style.setProperty("--bsc-icon-color", this._config.icon_color) : !r && this._config.icon_off_color ? this.style.setProperty("--bsc-icon-color", this._config.icon_off_color) : this.style.removeProperty("--bsc-icon-color");
@@ -2065,26 +2069,30 @@ var $ = class extends Z {
 	_getEntityRange(e) {
 		let t = this._getDomain(e.entity_id), n = this._config.attribute;
 		if (n === "color_temp_kelvin") return {
-			min: 2200,
-			max: 6500
+			min: this._toNumber(e.attributes?.min_color_temp_kelvin, o),
+			max: this._toNumber(e.attributes?.max_color_temp_kelvin, s)
+		};
+		if (n === "hue") return {
+			min: 0,
+			max: 360
 		};
 		switch (t) {
 			case "number":
 			case "input_number": return {
-				min: this._toNumber(e.attributes?.min, s.min),
-				max: this._toNumber(e.attributes?.max, s.max)
+				min: this._toNumber(e.attributes?.min, l.min),
+				max: this._toNumber(e.attributes?.max, l.max)
 			};
 			case "climate":
 			case "water_heater": return n === "humidity" ? {
 				min: 0,
 				max: 100
 			} : {
-				min: this._toNumber(e.attributes?.min_temp, s.min),
-				max: this._toNumber(e.attributes?.max_temp, s.max)
+				min: this._toNumber(e.attributes?.min_temp, l.min),
+				max: this._toNumber(e.attributes?.max_temp, l.max)
 			};
 			default: return {
-				min: s.min,
-				max: s.max
+				min: l.min,
+				max: l.max
 			};
 		}
 	}
@@ -2126,9 +2134,9 @@ var $ = class extends Z {
 		this.dataset.domain = this._getDomain(e.entity_id), this.dataset.state = this._effectiveStatus;
 	}
 	render() {
-		if (this._entity && !(this._entity in (this._hass?.states ?? {}))) return this._showError(`${x("common.no_entity")}: ${this._entity}`);
+		if (this._entity && !(this._entity in (this._hass?.states ?? {}))) return this._showError(`${S("common.no_entity")}: ${this._entity}`);
 		let e = this._effectiveState, t = this._effectiveStatus, n = this._effectiveName, r = (this._entity || "light.example_light").split(".")[0], i = (this._config.colorize && !0) ?? !1, a = (this._config.show_percentage && !0) ?? !1, o = (this._config.bold_text && !0) ?? !1, s = this._config.no_scale !== !0, c = this._config.no_transition_animation !== !0, l = this._config.vertical === !0, u = this._config.use_alternative_slider_color === !0 ? "var(--paper-slider-active-color, #f9d2b0)" : "var(--bsc-active-color)";
-		return this.style.setProperty("--bsc-default-slider-color", u), this._setStyleProperty("--bsc-background", this._config.background_color), this._setStyleProperty("--bsc-primary-text-color", this._config.text_color), this._setStyleProperty("--bsc-slider-color", this._config.color), this._setStyleProperty("--bsc-border-color", this._config.border_color), this._setStyleProperty("--bsc-border-radius", this._config.border_radius, this._normalizeCssLength), this._setStyleProperty("--bsc-border-style", this._config.border_style), this._setStyleProperty("--bsc-border-width", this._config.border_width, this._normalizeCssLength), this._setStyleProperty("--bsc-height", this._config.height, this._normalizeCssLength), this._setStyleProperty("--bsc-width", this._config.width, this._normalizeCssLength), this._setStyleProperty("--bsc-icon-size", this._config.icon_size, this._normalizeCssLength), this._setStyleProperty("--bsc-icon-box-size", this._config.icon_box_size, this._normalizeCssLength), this._setStyleProperty("--bsc-slider-opacity", this._config.slider_opacity), this._setStyleProperty("--bsc-text-size", this._config.text_size, this._normalizeCssLength), this.style.setProperty("--bsc-press-transition", s ? "transform 0.1s ease-out" : "none"), this.style.setProperty("--bsc-half-pressed-transform", s ? "scale(0.99)" : "none"), this.style.setProperty("--bsc-pressed-transform", s ? "scale(0.98)" : "none"), this.style.setProperty("--bsc-color-transition", c ? "background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-slider-transition", c ? "right 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-vertical-slider-transition", c ? "top 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-icon-transition", c ? "color 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), Et`
+		return this.style.setProperty("--bsc-default-slider-color", u), this._setStyleProperty("--bsc-background", this._config.background_color), this._setStyleProperty("--bsc-primary-text-color", this._config.text_color), this._setStyleProperty("--bsc-slider-color", this._config.color), this._setStyleProperty("--bsc-border-color", this._config.border_color), this._setStyleProperty("--bsc-border-radius", this._config.border_radius, this._normalizeCssLength), this._setStyleProperty("--bsc-border-style", this._config.border_style), this._setStyleProperty("--bsc-border-width", this._config.border_width, this._normalizeCssLength), this._setStyleProperty("--bsc-height", this._config.height, this._normalizeCssLength), this._setStyleProperty("--bsc-width", this._config.width, this._normalizeCssLength), this._setStyleProperty("--bsc-icon-size", this._config.icon_size, this._normalizeCssLength), this._setStyleProperty("--bsc-icon-box-size", this._config.icon_box_size, this._normalizeCssLength), this._setStyleProperty("--bsc-slider-opacity", this._config.slider_opacity), this._setStyleProperty("--bsc-text-size", this._config.text_size, this._normalizeCssLength), this.style.setProperty("--bsc-press-transition", s ? "transform 0.1s ease-out" : "none"), this.style.setProperty("--bsc-half-pressed-transform", s ? "scale(0.99)" : "none"), this.style.setProperty("--bsc-pressed-transform", s ? "scale(0.98)" : "none"), this.style.setProperty("--bsc-color-transition", c ? "background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-slider-transition", c ? "right 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-vertical-slider-transition", c ? "top 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), this.style.setProperty("--bsc-icon-transition", c ? "color 180ms ease-in-out, background-color 180ms ease-in-out, filter 180ms ease-in-out" : "none"), Ot`
       <ha-card
         id="container"
         class="${l ? "vertical" : ""}"
@@ -2172,12 +2180,12 @@ var $ = class extends Z {
 		return t.setConfig({
 			type: "error",
 			error: e
-		}), Et`
+		}), Ot`
       ${t}
     `;
 	}
 	static get styles() {
-		return et`
+		return tt`
       :host {
         --bsc-background: var(--card-background-color);
         --bsc-active-color: var(--state-light-on-color, var(--state-light-active-color, var(--state-active-color)));
@@ -2379,12 +2387,12 @@ var $ = class extends Z {
     `;
 	}
 };
-Q([j()], $.prototype, "_config", void 0), Q([j()], $.prototype, "_entity", void 0), Q([j()], $.prototype, "_state", void 0), console.info(`%c  BIG-SLIDER-CARD \n%c  ${x("common.version")} ${r}    `, "color: orange; font-weight: bold; background: black", "color: white; font-weight: bold; background: dimgray"), customElements.define("big-slider-card", $), window.customCards = window.customCards ?? [], window.customCards.push({
+Q([j()], $.prototype, "_config", void 0), Q([j()], $.prototype, "_entity", void 0), Q([j()], $.prototype, "_state", void 0), console.info(`%c  BIG-SLIDER-CARD \n%c  ${S("common.version")} ${r}    `, "color: orange; font-weight: bold; background: black", "color: white; font-weight: bold; background: dimgray"), customElements.define("big-slider-card", $), window.customCards = window.customCards ?? [], window.customCards.push({
 	type: "big-slider-card",
-	name: x("card.name"),
-	description: x("card.description"),
+	name: S("card.name"),
+	description: S("card.description"),
 	preview: !0,
-	getEntitySuggestion: (e, t) => o.includes(t.split(".")[0]) ? {
+	getEntitySuggestion: (e, t) => c.includes(t.split(".")[0]) ? {
 		type: "custom:big-slider-card",
 		config: {
 			type: "custom:big-slider-card",

--- a/src/big-slider-card.ts
+++ b/src/big-slider-card.ts
@@ -3,7 +3,9 @@ import { SlideGesture, type SlideGestureEvent } from '@nicufarmache/slide-gestur
 import { HassEntity } from "home-assistant-js-websocket";
 import { HomeAssistant } from './ha-types';
 import type { BigSliderCardConfig, MousePos } from './types';
-import { DEFAULT_CONFIG, SUPPORTED_DOMAINS, TAP_THRESHOLD } from './const';
+import {
+  DEFAULT_CONFIG, DEFAULT_MAX_KELVIN, DEFAULT_MIN_KELVIN, HUE_MAX, SUPPORTED_DOMAINS, TAP_THRESHOLD,
+} from './const';
 import { localize } from './localize/localize';
 import { state } from 'lit/decorators.js';
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -386,10 +388,14 @@ export class BigSliderCard extends LitElement {
     }
   }
 
+  /// Seeds the range before any entity state arrives; _getEntityRange takes
+  /// over with the entity's own capability once it does.
   _getAttributeDefaults(attribute: string, _domain?: string): Partial<BigSliderCardConfig> {
     switch (attribute) {
       case 'color_temp_kelvin':
-        return { min: 2200, max: 6500 };
+        return { min: DEFAULT_MIN_KELVIN, max: DEFAULT_MAX_KELVIN };
+      case 'hue':
+        return { min: 0, max: HUE_MAX };
       default:
         return {};
     }
@@ -990,7 +996,16 @@ export class BigSliderCard extends LitElement {
     const attr = this._config.attribute;
 
     if (attr === 'color_temp_kelvin') {
-      return { min: 2200, max: 6500 };
+      // Lights vary widely here, and a slider that cannot reach the warm or
+      // cool end of the bulb is worse than one scaled to it.
+      return {
+        min: this._toNumber(stateObj.attributes?.min_color_temp_kelvin, DEFAULT_MIN_KELVIN),
+        max: this._toNumber(stateObj.attributes?.max_color_temp_kelvin, DEFAULT_MAX_KELVIN),
+      };
+    }
+
+    if (attr === 'hue') {
+      return { min: 0, max: HUE_MAX };
     }
 
     switch (domain) {

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,6 +6,11 @@ export const SETTLE_TIME = 3000;
 export const HOLD_TIME = 600;
 export const MIN_SLIDE_TIME = 0;
 export const TAP_THRESHOLD = 5;
+// Used when a light does not report its own colour temperature capability.
+export const DEFAULT_MIN_KELVIN = 2200;
+export const DEFAULT_MAX_KELVIN = 6500;
+// Hue is a full turn of the colour wheel, in degrees.
+export const HUE_MAX = 360;
 export const MIN = 0;
 export const MAX = 100;
 export const SUPPORTED_DOMAINS = [

--- a/tests/calculations.test.ts
+++ b/tests/calculations.test.ts
@@ -123,6 +123,19 @@ describe('configuration and calculations', () => {
     const light = createEntity('light.test', 'on', { color_temp_kelvin: 3000 });
     const kelvinCard = createCard(light, { attribute: 'color_temp_kelvin' }).card;
     expect(kelvinCard._getRange()).toEqual({ min: 2200, max: 6500 });
+
+    const capableLight = createEntity('light.test', 'on', {
+      color_temp_kelvin: 3000, min_color_temp_kelvin: 2000, max_color_temp_kelvin: 6535,
+    });
+    const capableCard = createCard(capableLight, { attribute: 'color_temp_kelvin' }).card;
+    expect(capableCard._getEntityRange(capableLight)).toEqual({ min: 2000, max: 6535 });
+    // Falls back to the seeded defaults when the light reports no capability
+    expect(capableCard._getEntityRange(light)).toEqual({ min: 2200, max: 6500 });
+
+    const hueCard = createCard(light, { attribute: 'hue' }).card;
+    expect(hueCard._getRange()).toEqual({ min: 0, max: 360 });
+    expect(hueCard._getEntityRange(light)).toEqual({ min: 0, max: 360 });
+
     expect(DEFAULT_CONFIG.min).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Colour temperature was pinned to 2200-6500K in two places, so a bulb reporting a wider or narrower capability got a slider that could not reach its own ends - and with gradient: auto, a gradient that did not describe it. Home Assistant's colour temp picker and Mushroom's both read min_color_temp_kelvin and max_color_temp_kelvin from the light; this now does the same, keeping 2200-6500K as the fallback.

Hue fell through to the default 0-100 range, so a hue slider covered less than a third of the wheel. It now spans 0-360 degrees, which is what the hs_color value it writes actually expects.

## Acceptance criteria

- [ ] Color temperature matches what the light reports
- [ ] Hue shows all colors and matches mushroom's hue slider

## Change area

- [ ] Card behavior or gestures
- [ ] Home Assistant service calls
- [ ] Configuration or editor schema
- [x] Rendering or styling
- [ ] Localization
- [ ] Documentation only
- [ ] Release or generated bundle

## Verification

- [x] Added or updated regression tests
- [x] Ran relevant focused tests
- [x] Ran `npm run check`
- [x] Confirmed `dist/big-slider-card.js` was generated rather than hand-edited
- [x] Reviewed the final diff for unrelated changes

For visible changes:

- [x] Checked the light preview
- [x] Checked the dark preview
- [x] Checked horizontal and vertical layouts when applicable

## Compatibility and risk

<!-- Note affected domains, existing YAML behavior, service payloads, timers,
or any verification that was not performed. -->
